### PR TITLE
Added API endpoint for the next 6 weeks

### DIFF
--- a/librairies/affixes.js
+++ b/librairies/affixes.js
@@ -89,6 +89,48 @@ function getAffixByWeek(weekNumber) {
     return new Affix(affixLevel2, affixLevel4, affixLevel7, affixLevel10);
 }
 
+function allAffixesForAPI() {
+    var affixes = {};
+    exports.getAllAffixes()
+        .flatMap(a => a.affixes.map(b => Object.assign({level: a.fromLevel}, b)))
+        .forEach(a => affixes[a.id] = a);
+        
+
+    return affixes;
+}
+
+exports.getAffixesForAPI = function() {
+    var closestWednesday = getClosestWednesday();
+    var result = getWeekNumber(closestWednesday);
+
+    var functionResult = [];
+    var allAffxes = allAffixesForAPI();
+    for (i = 0; i < 6; i++) {
+        var affixDate = new Date(closestWednesday);
+        affixDate.setDate(affixDate.getDate() + (i * 7));
+        affixDate.setHours(0);
+        affixDate.setMinutes(0);
+        affixDate.setSeconds(0);
+        affixDate.setMilliseconds(0);
+        var currentAffixes = getAffixByWeek(result + i);
+        var affixes = [];
+        for (let a in currentAffixes) {
+            if (typeof a === 'string' && a.startsWith("level")) {
+                var affix = allAffxes[currentAffixes[a]];
+                affixes.push(affix);
+            }
+        }
+            
+        functionResult.push({
+            "date": affixDate, 
+            "week_offset": i,
+            "affixes": affixes,
+        });
+    }
+
+    return functionResult;
+};
+
 exports.getAffixes = function () {
     var closestWednesday = getClosestWednesday();
     var result = getWeekNumber(closestWednesday);

--- a/librairies/routes.js
+++ b/librairies/routes.js
@@ -6,6 +6,13 @@ function getRootUrl(req, res) {
   res.render('pages/index', { affixes: currentAffixes, affixesInfos: affixesLib.getAllAffixes(), moment: moment })
 }
 
+function api_show_week(req, res) {
+  var affixesLib = require('./affixes');
+
+  var affixes = affixesLib.getAffixesForAPI();
+  res.json(affixes);
+}
+
 function get404Url(req, res) {
   var affixesLib = require('./affixes');
   var moment = require('moment');
@@ -13,6 +20,7 @@ function get404Url(req, res) {
   res.render('pages/index', { affixes: affixesLib.getAffixes(), moment: moment })
 }
 
+exports.api_show_week = api_show_week
 exports.getRoutes = function (req, res, i18n) {
   var result;
   if (req.baseUrl === '') {

--- a/server.js
+++ b/server.js
@@ -31,7 +31,8 @@ var server = express()
   .use(favicon(path.join(__dirname, 'public', 'images/favicon.png')))
   .set('views', path.join(__dirname, 'views'))
   .set('view engine', 'ejs')
-  .get('/', (req, res) => routesLib.getRoutes(req, res, i18n));
+  .get('/', (req, res) => routesLib.getRoutes(req, res, i18n))
+  .get('/api/weeks/', routesLib.api_show_week);
 
 exports.listen = function(port) {
 	console.log('Listening on: ' + port);

--- a/test/server.js
+++ b/test/server.js
@@ -6,6 +6,7 @@ var server = require('./../server.js');
 describe('HTTP Server Test', function () {
     // The function passed to before() is called before running the test cases.
     before(function () {
+	console.log(server);
         server.listen(8989);
     });
 


### PR DESCRIPTION
This commit adds an API endpoint to query the current affix as well as upcoming affixes. 

An API call looks like this: 

```
$ curl http://localhost:5000/api/weeks -v | python3 -m json.tool
[
    {
        "date": "2018-11-28T00:00:00.000Z",
        "week_offset": 0,
        "affixes": [
            {
                "level": 2,
                "id": 10,
                "name": "Fortified",
                "difficulty": "hard"
            },
           ...
    }, {
        "date": "2018-12-05T00:00:00.000Z",
        "week_offset": 1,
        "affixes": [
            {
                "level": 2,
                "id": 9,
                "name": "Tyrannical",
                "difficulty": "hard"
            },
            ...
    }
]
```

Let me know what you think! I needed an API endpoint so I can interface your website with Siri (so that I can just ask: What are this week's affixes?). 

Could you also please add a license to your repository? 
